### PR TITLE
Fix to CWL file for tar inputs

### DIFF
--- a/docker/rnaseq-cgl-pipeline.cwl
+++ b/docker/rnaseq-cgl-pipeline.cwl
@@ -174,7 +174,7 @@ outputs:
 #      items: ["null", File]
       items: File
     outputBinding:
-      glob: '*.sortedByCoord.md.bam'
+      glob: '*.bam'
       doc: "BAM result files RNA-seq CGL pipeline"
 
 baseCommand: ["--logDebug"]

--- a/docker/rnaseq-cgl-pipeline.cwl
+++ b/docker/rnaseq-cgl-pipeline.cwl
@@ -53,17 +53,11 @@ hints:
     description: "The process requires at least 16G of RAM and we recommend 500GB or storage."
 
 inputs:
-  #if no tar files are going to be input 
-  #then use 
-  # "sample-tar": [],
-  #in the parameterized JSON file 
   sample-tar:
-    doc: "Absolute path(s) to sample tarballs"
-    type:
-      type: array
-      items: ["null", File]
-      inputBinding:
-        prefix: --sample-tar
+    doc: "Absolute path to sample tarball"
+    type: File[]?
+    inputBinding:
+      prefix: --sample-tar
 
   sample-single:
     doc: "Absolute path(s) to unpaired FASTQ files. FASTQ files are comma delimited. Ex: sample1,sample2,sample3,sample4"
@@ -180,7 +174,7 @@ outputs:
 #      items: ["null", File]
       items: File
     outputBinding:
-      glob: '*.bam'
+      glob: '*.sortedByCoord.md.bam'
       doc: "BAM result files RNA-seq CGL pipeline"
 
 baseCommand: ["--logDebug"]

--- a/docker/rnaseq-cgl-pipeline.cwl
+++ b/docker/rnaseq-cgl-pipeline.cwl
@@ -43,7 +43,7 @@ dct:creator:
 
 requirements:
   - class: DockerRequirement
-    dockerPull: "quay.io/ucsc_cgl/rnaseq-cgl-pipeline:3.0.2-1"
+    dockerPull: "quay.io/ucsc_cgl/rnaseq-cgl-pipeline:3.0.2-2"
 
 hints:
   - class: ResourceRequirement

--- a/src/toil_rnaseq/rnaseq_cgl_pipeline.py
+++ b/src/toil_rnaseq/rnaseq_cgl_pipeline.py
@@ -159,7 +159,8 @@ def bam_qc(job, config, star_output):
         transcriptome_id, sorted_id, wiggle_id, log_id = star_output
     else:
         transcriptome_id, sorted_id, log_id = star_output
-    return job.addChildJobFn(run_bam_qc, sorted_id, config, cores=cores).rv()
+    disk = 5 * sorted_id.size
+    return job.addChildJobFn(run_bam_qc, sorted_id, config, cores=cores, disk=disk).rv()
 
 
 def rsem_quantification(job, config, star_output):


### PR DESCRIPTION
This is fix allows the use of parameterized JSON input file that has no tar input file 