### PR TITLE
added code to provide output file basename

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -20,7 +20,7 @@ RUN curl https://get.docker.com/builds/Linux/x86_64/docker-1.12.3.tgz \
 RUN pip install toil==3.3.5
 
 # Install toil-rnaseq
-RUN pip install toil-rnaseq==3.0.2
+RUN pip install toil-rnaseq==3.1.1
 
 COPY wrapper.py /opt/rnaseq-pipeline/
 COPY README.md /opt/rnaseq-pipeline/

--- a/docker/Dockerfile.template
+++ b/docker/Dockerfile.template
@@ -20,7 +20,7 @@ RUN curl https://get.docker.com/builds/Linux/x86_64/docker-DOCKERVER.tgz \
 RUN pip install toil==3.3.5
 
 # Install toil-rnaseq
-RUN pip install toil-rnaseq==3.0.2
+RUN pip install toil-rnaseq==3.1.1
 
 COPY wrapper.py /opt/rnaseq-pipeline/
 COPY README.md /opt/rnaseq-pipeline/

--- a/docker/Makefile.template
+++ b/docker/Makefile.template
@@ -2,13 +2,12 @@
 build_tool = runtime-container.DONE
 name = quay.io/ucsc_cgl/rnaseq-cgl-pipeline
 git_commit ?= $(shell git log --pretty=oneline -n 1 | cut -f1 -d " ")
-short_tag = 3.0.1--DOCKERVER
+short_tag = 3.1.1--DOCKERVER
 long_tag = ${short_tag}--${git_commit}
 
 build: Dockerfile
 	docker build -t ${name}:${long_tag} .
-    -docker rmi ${name}:${short_tag}
-	docker tag -f ${name}:${long_tag} ${name}:${short_tag}
+	docker tag ${name}:${long_tag} ${name}:${short_tag}
 	touch ${build_tool}
 
 push: build

--- a/docker/Makefile.template
+++ b/docker/Makefile.template
@@ -7,7 +7,8 @@ long_tag = ${short_tag}--${git_commit}
 
 build: Dockerfile
 	docker build -t ${name}:${long_tag} .
-	docker tag ${name}:${long_tag} ${name}:${short_tag}
+	docker rmi ${name}:${short_tag}
+	docker tag -f ${name}:${long_tag} ${name}:${short_tag}
 	touch ${build_tool}
 
 push: build

--- a/docker/rnaseq-cgl-pipeline.cwl
+++ b/docker/rnaseq-cgl-pipeline.cwl
@@ -43,7 +43,7 @@ dct:creator:
 
 requirements:
   - class: DockerRequirement
-    dockerPull: "quay.io/ucsc_cgl/rnaseq-cgl-pipeline:3.0.2-3"
+    dockerPull: "quay.io/ucsc_cgl/rnaseq-cgl-pipeline:3.1.1"
 
 hints:
   - class: ResourceRequirement
@@ -143,6 +143,12 @@ inputs:
     doc: "Will set a cap on number of cores to use, default is all available cores."
     inputBinding:
       prefix: --cores
+
+  output-basename:
+    type: string?
+    doc: "Basename to use for naming the output files"
+    inputBinding:
+      prefix: --output-basename
 
 outputs:
   output_files:

--- a/docker/rnaseq-cgl-pipeline.cwl
+++ b/docker/rnaseq-cgl-pipeline.cwl
@@ -145,7 +145,7 @@ inputs:
       prefix: --cores
 
   output-basename:
-    type: string?
+    type: string
     doc: "Basename to use for naming the output files"
     inputBinding:
       prefix: --output-basename

--- a/docker/wrapper.py
+++ b/docker/wrapper.py
@@ -56,21 +56,21 @@ def call_pipeline(mount, args):
         else:
             log.info('Flag "--no-clean" was used, therefore {} was not deleted.'.format(work_dir))
 
-    #DEBUG !!!
-    print("DEBUG!!!!! output dir is "+mount+" and files are:")
-    print(os.listdir(mount))
-    fail_files = [fail_file for fail_file in os.listdir(mount) if fail_file.startswith("FAIL.") and fail_file.endswith(".tar.gz")]
-    print("fail files:", ' '.join(fail_files))
-    cmd = ["mv", mount+"/"+fail_file, mount+"/"+fail_file[len("FAIL."):]]
+    log.debug("output dir is {} and files are:\n{}:".format(mount, '\n'.join(os.listdir(mount))))
+    log.debug(os.listdir(mount))
+
+    fail_files = [os.path.join(mount, x) for x in os.listdir(mount) if x.startswith('FAIL')]
+
+    log.debug("fail files: {}".format(' '.join(fail_files)))
     for fail_file in fail_files:
-        print("moving "+mount+"/"+fail_file+" to "+mount+"/"+fail_file[len("FAIL."):])
+        cmd = ["mv", os.path.join(mount, fail_file, mount, fail_file.lstrip('FAIL.'))]
+        #print("moving "+mount+"/"+fail_file+" to "+mount+"/"+fail_file[len("FAIL."):])
         try:
             subprocess.check_call(cmd) 
         except subprocess.CalledProcessError as e:
-            print(e.message, file=sys.stderr)
+            log.error(e.message)
         except Exception as e:
-            print("\nERROR: FAIL file mv exception information:" + str(e), file=sys.stderr)
-    #END DEBUG !!!!
+            log.error("\nERROR: FAIL file mv exception information: {}".format(str(e)))
 
 
 
@@ -116,13 +116,8 @@ def fileURL(sample):
 
 
 def getSampleName(sample, output_basename):
-    if output_basename:
-        name = output_basename
-    else:
-        name = os.path.basename(sample).split('.')[0]
-        if name.endswith('R1') or name.endswith('R2'):
-            return name[:-2]
-    return name
+    #very temporary, output_basename will be required.
+    return output_basename
 
 
 def formatPairs(sample_pairs, work_mount):


### PR DESCRIPTION
added code to provide output file basename$
fixed command to create docker tags

worth noting 
-in input json file the basename given needs to match basename on output files or CWL will throw an exception.
-removed "docker rmi ${name}:${short_tag}" which may cause issues if you want to replace a docker image?