### PR TITLE
Add support for output file naming (resolves #57)

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -20,7 +20,7 @@ RUN curl https://get.docker.com/builds/Linux/x86_64/docker-1.12.3.tgz \
 RUN pip install toil==3.3.5
 
 # Install toil-rnaseq
-RUN pip install toil-rnaseq==3.0.2
+RUN pip install toil-rnaseq==3.1.1
 
 COPY wrapper.py /opt/rnaseq-pipeline/
 COPY README.md /opt/rnaseq-pipeline/

--- a/docker/Dockerfile.template
+++ b/docker/Dockerfile.template
@@ -20,7 +20,7 @@ RUN curl https://get.docker.com/builds/Linux/x86_64/docker-DOCKERVER.tgz \
 RUN pip install toil==3.3.5
 
 # Install toil-rnaseq
-RUN pip install toil-rnaseq==3.0.2
+RUN pip install toil-rnaseq==3.1.1
 
 COPY wrapper.py /opt/rnaseq-pipeline/
 COPY README.md /opt/rnaseq-pipeline/

--- a/docker/Makefile.template
+++ b/docker/Makefile.template
@@ -2,13 +2,13 @@
 build_tool = runtime-container.DONE
 name = quay.io/ucsc_cgl/rnaseq-cgl-pipeline
 git_commit ?= $(shell git log --pretty=oneline -n 1 | cut -f1 -d " ")
-short_tag = 3.0.1--DOCKERVER
+short_tag = 3.1.1--DOCKERVER
 long_tag = ${short_tag}--${git_commit}
 
 build: Dockerfile
 	docker build -t ${name}:${long_tag} .
-    -docker rmi ${name}:${short_tag}
-	docker tag -f ${name}:${long_tag} ${name}:${short_tag}
+	-docker rmi ${name}:${short_tag}
+	docker tag ${name}:${long_tag} ${name}:${short_tag}
 	touch ${build_tool}
 
 push: build

--- a/docker/rnaseq-cgl-pipeline.cwl
+++ b/docker/rnaseq-cgl-pipeline.cwl
@@ -43,7 +43,7 @@ dct:creator:
 
 requirements:
   - class: DockerRequirement
-    dockerPull: "quay.io/ucsc_cgl/rnaseq-cgl-pipeline:3.0.2-3"
+    dockerPull: "quay.io/ucsc_cgl/rnaseq-cgl-pipeline:3.1.1"
 
 hints:
   - class: ResourceRequirement
@@ -143,6 +143,12 @@ inputs:
     doc: "Will set a cap on number of cores to use, default is all available cores."
     inputBinding:
       prefix: --cores
+
+  output-basename:
+    type: string?
+    doc: "Basename to use for naming the output files"
+    inputBinding:
+      prefix: --output-basename
 
 outputs:
   output_files:

--- a/docker/wrapper.py
+++ b/docker/wrapper.py
@@ -60,7 +60,7 @@ def call_pipeline(mount, args):
     fail_files = [x for x in os.listdir(mount) if x.startswith('FAIL.')]
     log.info("fail files are:\n{}:".format('\n'.join(fail_files)))
     for fail_file in fail_files:
-        new_file = fail_file.lstrip('FAIL.')
+        new_file = fail_file[len('FAIL.'):]
         fail_file_path = os.path.join(mount, fail_file)
         new_file_path = os.path.join(mount, new_file)
         cmd = ["mv", fail_file_path, new_file_path]


### PR DESCRIPTION
Added support for basename for output file naming @jvivian 

Fixed most comments in Thomas' pull request. The ones I did not:
  I believe the '-f' switch for docker tag has been deprecated (check with CJ) so I removed it; it also failed in my tests with the '-f' but worked without it
  I left the original code for getSampleName which split on a '.' to try an minimize side effects of code changes
  