### PR TITLE
push short Docker tag to repo instead of long tag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -129,14 +129,9 @@ check_running_on_jenkins:
 clean_docker:
 	-cd docker && make clean
 
-test_docker:
-	$(python) setup.py sdist$
-	cd docker && make test
-	rm ./dist/toil-rnaseq*.tar.gz
-
 docker:
 	$(python) setup.py sdist$
-	cd docker && make
+	cd docker && make && make test
 	rm ./dist/toil-rnaseq*.tar.gz
 
 

--- a/docker/Makefile.template
+++ b/docker/Makefile.template
@@ -20,7 +20,7 @@ build: sdist Dockerfile
 
 push: build
 	# Requires ~/.dockercfg
-	docker push ${name}:${long_tag}
+	docker push ${name}:${short_tag}
 	
 test: build
 	python test.py ${long_tag}

--- a/jenkins.sh
+++ b/jenkins.sh
@@ -15,7 +15,6 @@ make prepare
 make develop
 make test
 make docker
-make test_docker
 make clean
 make pypi
 make push_docker


### PR DESCRIPTION
push short Docker tag to repo instead of long tag