### PR TITLE
fix image version tag

### DIFF
--- a/docker/Makefile.template
+++ b/docker/Makefile.template
@@ -6,8 +6,8 @@ git_commit ?= $(shell git log --pretty=oneline -n 1 | cut -f1 -d " ")
 #find the line with grep, trim whitespace, extract the text after the equals sign trim single quotes
 toil_rnaseq_version := $(shell grep '^version =' ../../version.py | tr -d [:space:] | cut -d= -f2- | tr -d "'")
 
-short_tag = ${toil_rnaseq_version}--DOCKERVER
-long_tag = ${short_tag}--${git_commit}
+short_tag = ${toil_rnaseq_version}-DOCKERVER
+long_tag = ${short_tag}-${git_commit}
 
 sdist:
 	cp ../../dist/toil-rnaseq*.tar.gz ./toil-rnaseq.tar.gz

--- a/docker/rnaseq-cgl-pipeline.cwl
+++ b/docker/rnaseq-cgl-pipeline.cwl
@@ -43,7 +43,7 @@ dct:creator:
 
 requirements:
   - class: DockerRequirement
-    dockerPull: "quay.io/ucsc_cgl/rnaseq-cgl-pipeline:3.2.1-1"
+    dockerPull: "quay.io/ucsc_cgl/rnaseq-cgl-pipeline:3.3.4-1.12.3"
 
 hints:
   - class: ResourceRequirement


### PR DESCRIPTION
This is to fix image version tag so it can be recognized by Dockstore by removing one of the hyphens between the RNA-Seq version and the Docker version. Also it updates the image version tag in the rnaseq-cgl-pipeline.cwl file so that Dockstore will be able to run the correct image. John is the new RNA Seq version (3.3.4?)