### PR TITLE
Add bam support with tests, GDC support, and user input (resolves #106, resolves #109, resolves #43, resolves #113)

### DIFF
--- a/src/toil_rnaseq/jobs.py
+++ b/src/toil_rnaseq/jobs.py
@@ -1,0 +1,133 @@
+import os
+from urlparse import urlparse
+
+from toil.lib.docker import dockerCheckOutput, dockerCall
+from toil_lib.files import copy_files
+from toil_lib.tools.preprocessing import run_cutadapt
+from toil_lib.urls import download_url
+
+from utils import docker_path
+
+
+def cleanup_ids(job, ids_to_delete):
+    """
+    Delete fileStoreIDs for files no longer needed
+
+    :param JobFunctionWrappingJob job: passed automatically by Toil
+    :param list ids_to_delete: list of FileStoreIDs to delete
+    """
+    [job.fileStore.deleteGlobalFile(x) for x in ids_to_delete if x is not None]
+
+
+def download_and_process_bam(job, config):
+    """
+    Download and process a BAM by converting it to a FASTQ pair
+
+    :param JobFunctionWrappingJob job: passed automatically by Toil
+    :param Namespace config: Argparse Namespace object containing argument inputs
+    :return: FileStoreIDs of R1 / R2 fastq files
+    """
+    work_dir = job.fileStore.getLocalTempDir()
+    parsed_url = urlparse(config.url)
+
+    # Download BAM
+    if parsed_url.scheme == 'gdc':
+        bam_path = download_bam_from_gdc(job, work_dir, url=config.url, token=config.gdc_token)
+    else:
+        bam_path = download_url(config.url, work_dir=work_dir, name='input.bam', s3_key_path=config.ssec)
+
+    # Convert to fastq pairs
+    r1, r2 = convert_bam_to_fastq(job, bam_path)
+
+    # Return fastq files
+    if config.cutadapt:
+        disk = 2 * (r1.size + r2.size)
+        return job.addChildJobFn(run_cutadapt, r1, r2, config.fwd_3pr_adapter,
+                                 config.rev_3pr_adapter, disk=disk).rv()
+    return r1, r2
+
+
+def assert_bam_is_paired_end(job, bam_path, region='chr6'):
+    """
+    Confirm that a BAM is paired-end and not single-end. Raises an error if not paired-end
+
+    :param JobFunctionWrappingJob job: passed automatically by Toil
+    :param str region: Region of the genome to select
+    :param str bam_path: Path to BAM
+    """
+    # Check if BAM index exists, otherwise index BAM
+    if not os.path.exists(os.path.splitext(bam_path)[0] + '.bai'):
+        index_bam(job, bam_path)
+
+    docker_bam_path = docker_path(bam_path)
+    work_dir = os.path.dirname(os.path.abspath(bam_path))
+    parameters = ['view', '-c', '-f', '1',
+                  docker_bam_path,
+                  region]  # Chr6 chosen for testing, any region with reads will work
+    out = dockerCheckOutput(job, workDir=work_dir, parameters=parameters,
+                            tool='quay.io/ucsc_cgl/samtools:1.5--98b58ba05641ee98fa98414ed28b53ac3048bc09')
+    assert int(out.strip()) != 0, 'BAM is not paired-end, aborting run.'
+
+
+def index_bam(job, bam_path):
+    """
+    Creates a BAM index (.bai) in the same directory as the BAM
+    Indexing is necessary for viewing slices of the BAM
+
+    :param JobFunctionWrappingJob job: passed automatically by Toil
+    :param str bam_path: Path to BAM
+    """
+    work_dir = os.path.dirname(os.path.abspath(bam_path))
+    parameters = ['index', docker_path(bam_path)]
+    dockerCall(job, workDir=work_dir, parameters=parameters,
+               tool='quay.io/ucsc_cgl/samtools:1.5--98b58ba05641ee98fa98414ed28b53ac3048bc09')
+
+
+def convert_bam_to_fastq(job, bam_path, check_paired=True, ignore_validation_errors=True):
+    """
+    Converts BAM to a pair of FASTQ files
+
+    :param JobFunctionWrappingJob job: passed automatically by Toil
+    :param str bam_path: Path to BAM
+    :param bool check_paired: If True, checks whether BAM is paired-end
+    :return: FileStoreIDs for R1 and R2
+    :rtype: tuple
+    """
+    if check_paired:
+        assert_bam_is_paired_end(job, bam_path)
+
+    work_dir = os.path.dirname(os.path.abspath(bam_path))
+    parameters = ['SamToFastq', 'I={}'.format(docker_path(bam_path)), 'F=/data/R1.fq', 'F2=/data/R2.fq']
+    if ignore_validation_errors:
+        parameters.append('VALIDATION_STRINGENCY=SILENT')
+    dockerCall(job=job, workDir=work_dir, parameters=parameters,
+               tool='quay.io/ucsc_cgl/picardtools:2.10.9--23fc31175415b14dbf337216f9ae14d3acc3d1eb')
+    r1 = job.fileStore.writeGlobalFile(os.path.join(work_dir, 'R1.fq'))
+    r2 = job.fileStore.writeGlobalFile(os.path.join(work_dir, 'R2.fq'))
+    return r1, r2
+
+
+def download_bam_from_gdc(job, work_dir, url, token):
+    """
+    Downloads BAM file from the GDC using an url (format: "gdc://<GDC ID>") and a GDC access token
+
+    :param JobFunctionWrappingJob job: passed automatically by Toil
+    :param str work_dir: Directory being mounted into Docker
+    :param str url: gdc URL to be downloaded
+    :param str token: Full path to token
+    :return: Path to BAM
+    :rtype: str
+    """
+    assert token, 'gdc_token is missing which is required for downloading. Check config.'
+    copy_files([os.path.abspath(token)], work_dir)
+
+    parsed_url = urlparse(url)
+    parameters = ['download',
+                  '-d', '/data',
+                  '-t', '/data/{}'.format(os.path.basename(token)),
+                  parsed_url.netloc]
+    dockerCall(job, tool='sbamin/gdc-client:1.2.0', parameters=parameters, workDir=work_dir)
+    files = [x for x in os.listdir(os.path.join(work_dir, parsed_url.netloc)) if x.lower().endswith('.bam')]
+    assert len(files) == 1, 'More than one BAM found from GDC URL: {}'.format(files)
+    bam_path = os.path.join(work_dir, parsed_url.netloc, files[0])
+    return bam_path

--- a/src/toil_rnaseq/test/test_rnaseq_cgl.py
+++ b/src/toil_rnaseq/test/test_rnaseq_cgl.py
@@ -94,7 +94,7 @@ class RNASeqCGLTest(TestCase):
                     fastqc: true
                     cutadapt:
                     ssec:
-                    gtkey:
+                    gdc-token:
                     wiggle:
                     save-bam:
                     fwd-3pr-adapter: AGATCGGAAGAG

--- a/src/toil_rnaseq/utils.py
+++ b/src/toil_rnaseq/utils.py
@@ -47,7 +47,10 @@ def parse_samples(path_to_manifest=None, sample_urls=None):
 
 def generate_config():
     return textwrap.dedent("""
-        # RNA-seq CGL Pipeline configuration file
+        ##############################################################################################################
+        #                               TOIL RNA-SEQ PIPELINE CONFIGURATION FILE                                     #
+        ##############################################################################################################
+
         # This configuration file is formatted in YAML. Simply write the value (at least one space) after the colon.
         # Edit the values in this configuration file and then rerun the pipeline: "toil-rnaseq run"
         # Just Kallisto or STAR/RSEM can be run by supplying only the inputs to those tools
@@ -59,7 +62,7 @@ def generate_config():
         # Comments (beginning with #) do not need to be removed. Optional parameters left blank are treated as false.
         
         ##############################################################################################################
-        #                                           REQUIRED OPTIONS
+        #                                           REQUIRED OPTIONS                                                 #
         ##############################################################################################################
 
         # Required: Output location of sample. Can be full path to a directory or an s3:// URL
@@ -67,7 +70,7 @@ def generate_config():
         output-dir: 
         
         ##############################################################################################################
-        #                           WORKFLOW OPTIONS (Alignment and Quantification)
+        #                           WORKFLOW OPTIONS (Alignment and Quantification)                                  #
         ##############################################################################################################
         
         # URL {scheme} to index tarball used by STAR
@@ -81,7 +84,7 @@ def generate_config():
         kallisto-index: s3://cgl-pipeline-inputs/rnaseq_cgl/kallisto_hg38.idx
         
         ##############################################################################################################
-        #                                   WORKFLOW OPTIONS (Quality Control)
+        #                                   WORKFLOW OPTIONS (Quality Control)                                       #
         ##############################################################################################################
         
         # If true, will preprocess samples with cutadapt using adapter sequences.
@@ -100,17 +103,17 @@ def generate_config():
         bamqc: 
         
         ##############################################################################################################
-        #                   CREDENTIAL OPTIONS (for downloading samples from secure locations)
+        #                   CREDENTIAL OPTIONS (for downloading samples from secure locations)                       #
         ##############################################################################################################        
 
         # Optional: Provide a full path to a 32-byte key used for SSE-C Encryption in Amazon
         ssec: 
 
         # Optional: Provide a full path to the token.txt used to download from the GDC
-        gdc-token:
+        gdc-token: 
         
         ##############################################################################################################
-        #                                   ADDITIONAL FILE OUTPUT OPTIONS
+        #                                   ADDITIONAL FILE OUTPUT OPTIONS                                           #
         ##############################################################################################################        
 
         # Optional: If true, saves the wiggle file (.bg extension) output by STAR
@@ -123,12 +126,69 @@ def generate_config():
         save-bam: 
         
         ##############################################################################################################
-        #                                           DEVELOPER OPTIONS
+        #                                           DEVELOPER OPTIONS                                                #
         ##############################################################################################################        
 
         # Optional: If true, uses resource requirements appropriate for continuous integration
         ci-test: 
     """.format(scheme=[x + '://' for x in schemes])[1:])
+
+
+def user_input_config(config_path):
+    """
+    User input of pipeline configuration file
+
+    :param str config_path: Path to configuration file
+    :return: Configuration file path or None if user skips
+    :rtype: str
+    """
+    print('\n\t\t\tUser Input of Toil-rnaseq Configuration File\n')
+    start = raw_input('Type Y/y and hit enter to continue: ').lower()
+    if start != 'y':
+        return None
+    print('User will see comments for a configuation option followed by "<OPTION>: [Default Value]"')
+    print('\tN/n to skip\n\ttrue/false for boolean statements\n\tq/quit to stop\n\tEnter key to submit option\n')
+
+    config = OrderedDict()
+    comments = defaultdict(list)
+    quit_flag = False
+    config_template = generate_config().split('\n')
+    for line in config_template:
+        if not line.startswith('#') and line:
+            option, default = line.split(': ')
+
+            # Fetch comments for current option
+            index = config_template.index(line) - 1
+            while True:
+                comments[option].insert(0, config_template[index])
+                index -= 1
+                if not config_template[index]:
+                    break
+            if quit_flag:
+                config[option] = default
+                continue
+            print('\n'.join(comments[option]) + '\n\n')
+
+            # Show option and get user input
+            user_input = None
+            while not user_input:
+                user_input = raw_input('\n{}: [{}]\n\tUser Input: '.format(option, default)).lower()
+            if user_input == 'q' or user_input == 'quit':
+                quit_flag = True
+                config[option] = default
+                continue
+            elif user_input == 'n':
+                config[option] = default
+                continue
+            else:
+                config[option] = user_input
+
+    print('Writing out configuration file to: {}'.format(config_path))
+    with open(config_path, 'w') as f:
+        for option in config:
+            f.write('\n'.join(comments[option]))
+            f.write('\n{}: {}\n\n'.format(option, config[option]))
+    return config_path
 
 
 def generate_manifest():
@@ -139,7 +199,7 @@ def generate_manifest():
         #   filetype    Filetype of the sample. Options: "tar", "fq", or "bam" for tarball, fastq/fastq.gz, or BAM
         #   paired      Indicates whether the data is paired or single-ended. Options:  "paired" or "single"
         #   UUID        This should be a unique identifier for the sample to be processed
-        #   URL         A URL {scheme} pointing to the sample
+        #   URL         A URL starting with {scheme} that points to the sample
         #
         #   If sample is being submitted as a fastq or several fastqs, provide URLs separated by a comma.
         #   If providing paired fastqs, alternate the fastqs so every R1 is paired with its R2 as the next URL.
@@ -148,9 +208,9 @@ def generate_manifest():
         #   Samples consisting of tarballs with fastq files inside must follow the file name convention of
         #   ending in an R1/R2 or _1/_2 followed by one of the 4 extensions: .fastq.gz, .fastq, .fq.gz, .fq
         #
-        #   BAMs are now accepted, but must have been aligned from paired reads not single-end reads.
+        #   BAMs are accepted, but must have been aligned from paired reads NOT single-end reads.
         #
-        #   GDC URLs may only point to individual BAM files, no other format is accepted.
+        #   GDC URLs may only point to individual BAM files. No other format is accepted.
         #
         #   Examples of several combinations are provided below. Lines beginning with # are ignored.
         #
@@ -165,17 +225,64 @@ def generate_manifest():
         """.format(scheme=[x + '://' for x in schemes])[1:])
 
 
+def user_input_manifest(manifest_path):
+    """
+    User input of pipeline manifest file
+
+    :param str manifest_path: Path to write out manifest
+    :return: Path to manifest or None if user skips
+    :rtype: str
+    """
+    print('\n\t\t\tUser Input of Toil-rnaseq Manifest')
+    start = raw_input('Type Y/y and hit enter to continue: ').lower()
+    if start != 'y':
+        return None
+    print('\n'.join(generate_manifest().split('\n')[:-1]))  # Don't print last line of manifest
+    print('\n\nFollow the prompts to enter sample information, based on the information above.\n')
+
+    samples = []
+    while True:
+        filetype, paired, uuid = None, None, None
+        url = 'bad-url'
+        while filetype not in ['tar', 'fq', 'bam']:
+            filetype = raw_input('Enter the filetype of the sample: ')
+        while paired not in ['paired', 'single']:
+            paired = raw_input('Enter whether sample is paired or single-end: ')
+        uuid = raw_input('Enter unique name (or UUID) of sample: ')
+        while urlparse(url).scheme not in schemes:
+            url = raw_input('Enter URL for sample: ')
+        samples.append((filetype, paired, uuid, url))
+
+        # Escape loop
+        user = raw_input('\nType q/quit to exit or enter any other key to add more samples\n').lower()
+        if user == 'q' or user == 'quit':
+            break
+
+    print('Writing out manifest file to: {}'.format(manifest_path))
+    with open(manifest_path, 'w') as f:
+        f.write(generate_manifest() + '\n')
+        for sample in samples:
+            assert len(sample) == 4, 'Something is wrong. Expected 4 options per sample: {}'.format(sample)
+            f.write('\t'.join(sample) + '\n')
+    return manifest_path
+
+
 def generate_file(file_path, generate_func):
     """
     Checks file existance, generates file, and provides message
 
     :param str file_path: File location to generate file
     :param func generate_func: Function used to generate file
+    :return: Path to file
+    :rtype: str
     """
-    require(not os.path.exists(file_path), file_path + ' already exists!')
-    with open(file_path, 'w') as f:
-        f.write(generate_func())
-    print('\t{} has been generated in the current working directory.'.format(os.path.basename(file_path)))
+    if os.path.exists(file_path):
+        print('File "{}" already exists! Doing nothing.'.format(file_path))
+    else:
+        with open(file_path, 'w') as f:
+            f.write(generate_func())
+        print('\t{} has been generated in the current working directory.'.format(os.path.basename(file_path)))
+    return file_path
 
 
 def move_or_upload(config, files):

--- a/src/toil_rnaseq/utils.py
+++ b/src/toil_rnaseq/utils.py
@@ -1,12 +1,16 @@
+from __future__ import print_function
+
 import os
 import textwrap
 from urlparse import urlparse
+
+from collections import OrderedDict, defaultdict
 
 from toil_lib import require
 from toil_lib.files import copy_files
 from toil_lib.urls import s3am_upload
 
-schemes = ('http', 'file', 's3', 'ftp', 'gnos')
+schemes = ('file', 'http', 's3', 'ftp', 'gdc')
 
 
 def parse_samples(path_to_manifest=None, sample_urls=None):
@@ -30,7 +34,7 @@ def parse_samples(path_to_manifest=None, sample_urls=None):
                     require(len(sample) == 4, 'Bad manifest format! '
                                               'Expected 4 tab separated columns, got: {}'.format(sample))
                     file_type, paired, uuid, url = sample
-                    require(file_type == 'tar' or file_type == 'fq',
+                    require(file_type == 'tar' or file_type == 'fq' or file_type == 'bam',
                             '1st column must be "tar" or "fq": {}'.format(sample[0]))
                     require(paired == 'paired' or paired == 'single',
                             '2nd column must be "paired" or "single": {}'.format(sample[1]))
@@ -53,51 +57,77 @@ def generate_config():
         # S3 URLs follow the convention: s3://bucket/directory/file.txt
         #
         # Comments (beginning with #) do not need to be removed. Optional parameters left blank are treated as false.
+        
         ##############################################################################################################
-        # Required: URL {scheme} to index tarball used by STAR
-        star-index: s3://cgl-pipeline-inputs/rnaseq_cgl/starIndex_hg38_no_alt.tar.gz
-
-        # Required: URL {scheme} to kallisto index file.
-        kallisto-index: s3://cgl-pipeline-inputs/rnaseq_cgl/kallisto_hg38.idx
-
-        # Required: URL {scheme} to reference tarball used by RSEM
-        rsem-ref: s3://cgl-pipeline-inputs/rnaseq_cgl/rsem_ref_hg38_no_alt.tar.gz
+        #                                           REQUIRED OPTIONS
+        ##############################################################################################################
 
         # Required: Output location of sample. Can be full path to a directory or an s3:// URL
-        # Warning: S3 buckets must exist prior to upload or it will fail.
-        output-dir:
+        # WARNING: S3 buckets must exist prior to upload, or it will fail.
+        output-dir: 
+        
+        ##############################################################################################################
+        #                           WORKFLOW OPTIONS (Alignment and Quantification)
+        ##############################################################################################################
+        
+        # URL {scheme} to index tarball used by STAR
+        star-index: s3://cgl-pipeline-inputs/rnaseq_cgl/starIndex_hg38_no_alt.tar.gz
+        
+        # URL {scheme} to reference tarball used by RSEM
+        # Running RSEM requires a star-index as a well as an rsem-ref
+        rsem-ref: s3://cgl-pipeline-inputs/rnaseq_cgl/rsem_ref_hg38_no_alt.tar.gz
 
-        # Optional: If true, will preprocess samples with cutadapt using adapter sequences.
+        # URL {scheme} to kallisto index file. 
+        kallisto-index: s3://cgl-pipeline-inputs/rnaseq_cgl/kallisto_hg38.idx
+        
+        ##############################################################################################################
+        #                                   WORKFLOW OPTIONS (Quality Control)
+        ##############################################################################################################
+        
+        # If true, will preprocess samples with cutadapt using adapter sequences.
         cutadapt: true
+        
+        # Adapter sequence to trim when running CutAdapt. Defaults set for Illumina
+        fwd-3pr-adapter: AGATCGGAAGAG
 
-        # Optional: If true, will run FastQC and include QC in sample output
+        # Adapter sequence to trim (for reverse strand) when running CutAdapt. Defaults set for Illumina
+        rev-3pr-adapter: AGATCGGAAGAG
+
+        # If true, will run FastQC and include QC in sample output
         fastqc: true
 
         # Optional: If true, will run BAM QC (as specified by California Kid's Cancer Comparison)
-        bamqc:
-
-        # Adapter sequence to trim. Defaults set for Illumina
-        fwd-3pr-adapter: AGATCGGAAGAG
-
-        # Adapter sequence to trim (for reverse strand). Defaults set for Illumina
-        rev-3pr-adapter: AGATCGGAAGAG
+        bamqc: 
+        
+        ##############################################################################################################
+        #                   CREDENTIAL OPTIONS (for downloading samples from secure locations)
+        ##############################################################################################################        
 
         # Optional: Provide a full path to a 32-byte key used for SSE-C Encryption in Amazon
-        ssec:
+        ssec: 
 
-        # Optional: Provide a full path to a CGHub Key used to access GNOS hosted data
-        gtkey:
+        # Optional: Provide a full path to the token.txt used to download from the GDC
+        gdc-token:
+        
+        ##############################################################################################################
+        #                                   ADDITIONAL FILE OUTPUT OPTIONS
+        ##############################################################################################################        
 
         # Optional: If true, saves the wiggle file (.bg extension) output by STAR
         # WARNING: Requires STAR sorting, which has memory leak issues that can crash the pipeline. 
-        wiggle:
+        wiggle: 
 
-        # Optional: If true, saves the aligned bam (by coordinate) produced by STAR
+        # Optional: If true, saves the aligned BAM (by coordinate) produced by STAR
         # You must also specify an ssec key if you want to upload to the s3-output-dir
-        save-bam:
+        # as read data is assumed to be controlled access
+        save-bam: 
+        
+        ##############################################################################################################
+        #                                           DEVELOPER OPTIONS
+        ##############################################################################################################        
 
         # Optional: If true, uses resource requirements appropriate for continuous integration
-        ci-test:
+        ci-test: 
     """.format(scheme=[x + '://' for x in schemes])[1:])
 
 
@@ -106,7 +136,7 @@ def generate_manifest():
         #   Edit this manifest to include information pertaining to each sample to be run.
         #   There are 4 tab-separated columns: filetype, paired/unpaired, UUID, URL(s) to sample
         #
-        #   filetype    Filetype of the sample. Options: "tar" or "fq", for tarball/tarfile or fastq/fastq.gz
+        #   filetype    Filetype of the sample. Options: "tar", "fq", or "bam" for tarball, fastq/fastq.gz, or BAM
         #   paired      Indicates whether the data is paired or single-ended. Options:  "paired" or "single"
         #   UUID        This should be a unique identifier for the sample to be processed
         #   URL         A URL {scheme} pointing to the sample
@@ -118,6 +148,10 @@ def generate_manifest():
         #   Samples consisting of tarballs with fastq files inside must follow the file name convention of
         #   ending in an R1/R2 or _1/_2 followed by one of the 4 extensions: .fastq.gz, .fastq, .fq.gz, .fq
         #
+        #   BAMs are now accepted, but must have been aligned from paired reads not single-end reads.
+        #
+        #   GDC URLs may only point to individual BAM files, no other format is accepted.
+        #
         #   Examples of several combinations are provided below. Lines beginning with # are ignored.
         #
         #   tar paired  UUID_1  file:///path/to/sample.tar
@@ -125,6 +159,7 @@ def generate_manifest():
         #   tar single  UUID_3  http://sample-depot.com/single-end-sample.tar
         #   tar paired  UUID_4  s3://my-bucket-name/directory/paired-sample.tar.gz
         #   fq  single  UUID_5  s3://my-bucket-name/directory/single-end-file.fq
+        #   bam paired  UUID_6  gdc://1a5f5e03-4219-4704-8aaf-f132f23f26c7
         #
         #   Place your samples below, one per line.
         """.format(scheme=[x + '://' for x in schemes])[1:])
@@ -135,7 +170,7 @@ def generate_file(file_path, generate_func):
     Checks file existance, generates file, and provides message
 
     :param str file_path: File location to generate file
-    :param function generate_func: Function used to generate file
+    :param func generate_func: Function used to generate file
     """
     require(not os.path.exists(file_path), file_path + ' already exists!')
     with open(file_path, 'w') as f:
@@ -151,11 +186,12 @@ def move_or_upload(config, files):
         copy_files(file_paths=files, output_dir=config.output_dir)
 
 
-def cleanup_ids(job, ids_to_delete):
+def docker_path(path):
     """
-    Delete fileStoreIDs for files no longer needed
+    Converts a path to a file to a "docker path" which replaces the dirname with '/data'
 
-    :param JobFunctionWrappingJob job: passed automatically by Toil
-    :param list ids_to_delete: list of FileStoreIDs to delete
+    :param str path: Path to file
+    :return: Path for use in Docker parameters
+    :rtype: str
     """
-    [job.fileStore.deleteGlobalFile(x) for x in ids_to_delete if x is not None]
+    return os.path.join('/data', os.path.basename(path))


### PR DESCRIPTION
- Added BAM support with tests
    - Test bam is derived from open-access CCLE data
- Supports BAM downloads from GDC
- Users can now fill in manifest and config via prompts
- `gtkey` for CGHub use deprecated and replaced with `gdc-token`