### PR TITLE
Fix broken Docker builds (resolves #164)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -63,6 +63,7 @@ sdist: check_venv
 	$(python) setup.py sdist
 clean_sdist:
 	- rm -rf dist
+	- rm -rf .pytest_cache
 
 
 test: check_venv check_build_reqs

--- a/docker/Dockerfile.template
+++ b/docker/Dockerfile.template
@@ -13,8 +13,8 @@ RUN apt-get update && apt-get install -y \
     ca-certificates
 
 # Get the Docker binary
-RUN curl https://get.docker.com/builds/Linux/x86_64/docker-DOCKERVER.tgz \
-         | tar -xvzf - --transform='s,[^/]*/,,g' -C /usr/local/bin/ \
+RUN curl https://download.docker.com/linux/static/stable/x86_64/docker-DOCKERVER-ce.tgz \
+         | tar -xvzf - -C /tmp && mv /tmp/docker/* /usr/local/bin/ \
          && chmod u+x /usr/local/bin/docker
 
 # Set up a virtual environment with the system site package option so Toil

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -1,5 +1,5 @@
 # Definitions
-docker_versions = 1.12.3 1.11.2 1.10.3 #1.9.1 1.8.3 1.7.1 1.6.2
+docker_versions = 17.03.0 17.06.0 17.09.0 18.03.0 18.06.0
 gen_directories = $(docker_versions:=.docker)
 build_tool = runtime-container.DONE
 


### PR DESCRIPTION
Docker removed the links we were using to pull binaries. 

Will no longer support versions: 1.12.13, 1.11.2, 1.10.3 as these have been removed
Now support versions: 17.03.0, 17.06.0, 17.09.0, 18.03.0, and 18.06.0